### PR TITLE
Fix: Remove trailing comma from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "typescript": "^1.5.0-beta",
+    "typescript": "^1.5.0-beta"
   }
 }


### PR DESCRIPTION
@fcoury 
I removed a trailing comma, it prevented package.json to be parsed
