### PR TITLE
Added http-server to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "http-server": "^0.8.0",
     "typescript": "^1.5.0-beta"
   }
 }


### PR DESCRIPTION
In the book on page 10 it says...

We have one more step to test our application. We need to run a test web-server to serve our app from. If you did npm install earlier then you will have a web server you can use like so. 

However, http-server is not in the package.json.
